### PR TITLE
mint-arena: Fix changing engine latch cvars in Team Arena menu

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -2393,7 +2393,7 @@ static void CG_FeederSelection(float feederID, int index) {
 static float CG_Cvar_Get(const char *cvar) {
 	char buff[128];
 	memset(buff, 0, sizeof(buff));
-	trap_Cvar_VariableStringBuffer(cvar, buff, sizeof(buff));
+	trap_Cvar_LatchedVariableStringBuffer(cvar, buff, sizeof(buff));
 	return atof(buff);
 }
 
@@ -2471,7 +2471,7 @@ void CG_LoadHudMenu( void ) {
 	cgDC.runScript = &CG_RunMenuScript;
 	cgDC.getTeamColor = &CG_GetTeamColor;
 	cgDC.setCVar = trap_Cvar_Set;
-	cgDC.getCVarString = trap_Cvar_VariableStringBuffer;
+	cgDC.getCVarString = trap_Cvar_LatchedVariableStringBuffer;
 	cgDC.getCVarValue = CG_Cvar_Get;
 	cgDC.drawTextWithCursor = &CG_Text_PaintWithCursor;
 	cgDC.setOverstrikeMode = &trap_Key_SetOverstrikeMode;

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -4696,6 +4696,13 @@ static void UI_BuildQ3Model_List( void )
 }
 
 
+static float UI_Cvar_Get(const char *cvar) {
+	char buff[128];
+	memset(buff, 0, sizeof(buff));
+	trap_Cvar_LatchedVariableStringBuffer(cvar, buff, sizeof(buff));
+	return atof(buff);
+}
+
 
 /*
 =================
@@ -4735,8 +4742,8 @@ void UI_Init( qboolean inGameLoad, int maxSplitView ) {
 	uiInfo.uiDC.runScript = &UI_RunMenuScript;
 	uiInfo.uiDC.getTeamColor = &UI_GetTeamColor;
 	uiInfo.uiDC.setCVar = trap_Cvar_Set;
-	uiInfo.uiDC.getCVarString = trap_Cvar_VariableStringBuffer;
-	uiInfo.uiDC.getCVarValue = trap_Cvar_VariableValue;
+	uiInfo.uiDC.getCVarString = trap_Cvar_LatchedVariableStringBuffer;
+	uiInfo.uiDC.getCVarValue = UI_Cvar_Get;
 	uiInfo.uiDC.drawTextWithCursor = &UI_Text_PaintWithCursor;
 	uiInfo.uiDC.setOverstrikeMode = &trap_Key_SetOverstrikeMode;
 	uiInfo.uiDC.getOverstrikeMode = &trap_Key_GetOverstrikeMode;


### PR DESCRIPTION
Spearmint doesn't allow VMs to immediately change engine latch cvars
since it bypasses engine validation and reports incorrect state in
console.

The menus however edit / display cvars for applying later so they need
to work with the latched values.

Engine latch cvars referenced by Team Arena menu scripts
(start server and setup -> system menus):

sv_maxclients

r_allowExtensions
r_colorbits
r_ext_compressed_textures
r_mode
r_picmip
r_texturebits
r_vertexlight

Issue introduced in Spearmint July 12, 2014 commit:
"spearmint: Limit what Cvar_VM_Set can force change"